### PR TITLE
Allow setting default HttpClient timeout per factory

### DIFF
--- a/src/Impl/HttpClientFactoryBase.cs
+++ b/src/Impl/HttpClientFactoryBase.cs
@@ -8,6 +8,16 @@ namespace HttpClientFactory.Impl
     public abstract class HttpClientFactoryBase : IHttpClientFactory
     {
         private readonly ConcurrentDictionary<string, IHttpClient> _clients = new ConcurrentDictionary<string, IHttpClient>();
+        private readonly TimeSpan _defaultClientTimeout = TimeSpan.FromSeconds(20);
+
+        protected HttpClientFactoryBase()
+        {
+        }
+        protected HttpClientFactoryBase(TimeSpan defaultClientTimeout)
+        {
+            _defaultClientTimeout = defaultClientTimeout;
+        }
+
         public virtual HttpClient GetHttpClient(string url)
         {
             if (string.IsNullOrEmpty(url))
@@ -65,7 +75,7 @@ namespace HttpClientFactory.Impl
         {
             return new HttpClient(handler)
             {
-                Timeout = TimeSpan.FromSeconds(20)
+                Timeout = _defaultClientTimeout
             };
         }
 

--- a/src/Impl/PerHostHttpClientFactory.cs
+++ b/src/Impl/PerHostHttpClientFactory.cs
@@ -7,6 +7,14 @@ namespace HttpClientFactory.Impl
     /// </summary>
     public class PerHostHttpClientFactory : HttpClientFactoryBase
     {
+        public PerHostHttpClientFactory()
+        {
+        }
+
+        public PerHostHttpClientFactory(TimeSpan defaultClientTimeout) : base(defaultClientTimeout)
+        {
+        }
+
         protected override string GetCacheKey(string url)
         {
             return new Uri(url).Host;

--- a/src/Impl/PerUrlHttpClientFactory.cs
+++ b/src/Impl/PerUrlHttpClientFactory.cs
@@ -1,10 +1,20 @@
-﻿namespace HttpClientFactory.Impl
+﻿using System;
+
+namespace HttpClientFactory.Impl
 {
     /// <summary>
     /// same url use same HttpClient
     /// </summary>
     public class PerUrlHttpClientFactory : HttpClientFactoryBase
     {
+        public PerUrlHttpClientFactory()
+        {
+        }
+
+        public PerUrlHttpClientFactory(TimeSpan defaultClientTimeout) : base(defaultClientTimeout)
+        {
+        }
+
         protected override string GetCacheKey(string url)
         {
             return url;

--- a/test/UnitTest/PerHostHttpClientFactoryTests.cs
+++ b/test/UnitTest/PerHostHttpClientFactoryTests.cs
@@ -1,0 +1,27 @@
+using System;
+using HttpClientFactory.Impl;
+using Xunit;
+
+namespace UnitTest
+{
+    public class PerHostHttpClientFactoryTests
+    {
+        [Fact]
+        public void Should_Set_Client_Timeout_To_Default()
+        {
+            
+            var factory = new PerHostHttpClientFactory();
+            var client = factory.GetHttpClient("http://www.baidu.com");
+            Assert.Equal(client.Timeout, TimeSpan.FromSeconds(20));
+        }
+
+        [Fact]
+        public void Should_Set_Client_Timeout()
+        {
+            
+            var factory = new PerHostHttpClientFactory(TimeSpan.FromMinutes(15));
+            var client = factory.GetHttpClient("http://www.baidu.com");
+            Assert.Equal(client.Timeout, TimeSpan.FromMinutes(15));
+        }
+    }
+}

--- a/test/UnitTest/PerUrlHttpClientFactoryTests.cs
+++ b/test/UnitTest/PerUrlHttpClientFactoryTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using HttpClientFactory.Impl;
+using Xunit;
+
+namespace UnitTest
+{
+    public class PerUrlHttpClientFactoryTests
+    {
+        [Fact]
+        public void Should_Set_Client_Timeout_To_Default()
+        {
+            
+            var factory = new PerUrlHttpClientFactory();
+            var client = factory.GetHttpClient("http://www.baidu.com");
+            Assert.Equal(client.Timeout, TimeSpan.FromSeconds(20));
+        }
+
+        [Fact]
+        public void Should_Set_Client_Timeout()
+        {
+            
+            var factory = new PerUrlHttpClientFactory(TimeSpan.FromMinutes(15));
+            var client = factory.GetHttpClient("http://www.baidu.com");
+            Assert.Equal(client.Timeout, TimeSpan.FromMinutes(15));
+        }
+    }
+}


### PR DESCRIPTION
There exists some mechanism of passing settings by CallContext with HttpRunTimeSeetings class, but the timeout property is not used anyway.
I added a possibility to just pass the timeout in the factory constructor (parameterless constructors are added too, so this a non-breaking change).